### PR TITLE
Refactor Telemetry

### DIFF
--- a/CarrotMQ.Core.Test/MessageProcessing/MessageDistributorTest.cs
+++ b/CarrotMQ.Core.Test/MessageProcessing/MessageDistributorTest.cs
@@ -8,8 +8,8 @@ using CarrotMQ.Core.MessageProcessing.Delivery;
 using CarrotMQ.Core.MessageProcessing.Middleware;
 using CarrotMQ.Core.Protocol;
 using CarrotMQ.Core.Serialization;
+using CarrotMQ.Core.Telemetry;
 using CarrotMQ.Core.Test.Helper;
-using CarrotMQ.Core.Tracing;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 

--- a/CarrotMQ.Core.Test/MessageProcessing/ResponseSenderTest.cs
+++ b/CarrotMQ.Core.Test/MessageProcessing/ResponseSenderTest.cs
@@ -3,8 +3,8 @@ using CarrotMQ.Core.MessageProcessing;
 using CarrotMQ.Core.MessageProcessing.Middleware;
 using CarrotMQ.Core.Protocol;
 using CarrotMQ.Core.Serialization;
+using CarrotMQ.Core.Telemetry;
 using CarrotMQ.Core.Test.Helper;
-using CarrotMQ.Core.Tracing;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 

--- a/CarrotMQ.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/CarrotMQ.Core/Configuration/ServiceCollectionExtensions.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using CarrotMQ.Core.MessageProcessing;
 using CarrotMQ.Core.MessageProcessing.Middleware;
 using CarrotMQ.Core.Serialization;
-using CarrotMQ.Core.Tracing;
+using CarrotMQ.Core.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 

--- a/CarrotMQ.Core/MessageProcessing/CalledMethodResolver.cs
+++ b/CarrotMQ.Core/MessageProcessing/CalledMethodResolver.cs
@@ -7,6 +7,8 @@ namespace CarrotMQ.Core.MessageProcessing;
 /// </summary>
 public static class CalledMethodResolver
 {
+    private const string ResponsePrefix = "Response:";
+
     /// <summary>
     /// Builds a called method handler key based on the type of the message
     /// </summary>
@@ -24,7 +26,7 @@ public static class CalledMethodResolver
     /// <returns>The response key built from the specified request key.</returns>
     public static string BuildResponseCalledMethodKey(string requestKey)
     {
-        return $"Response:{requestKey}";
+        return $"{ResponsePrefix}{requestKey}";
     }
 
     /// <summary>

--- a/CarrotMQ.Core/MessageProcessing/ResponseSender.cs
+++ b/CarrotMQ.Core/MessageProcessing/ResponseSender.cs
@@ -6,7 +6,7 @@ using CarrotMQ.Core.Handlers.HandlerResults;
 using CarrotMQ.Core.MessageProcessing.Middleware;
 using CarrotMQ.Core.Protocol;
 using CarrotMQ.Core.Serialization;
-using CarrotMQ.Core.Tracing;
+using CarrotMQ.Core.Telemetry;
 using Microsoft.Extensions.Logging;
 
 namespace CarrotMQ.Core.MessageProcessing;

--- a/CarrotMQ.Core/Telemetry/CarrotActivityFactory.cs
+++ b/CarrotMQ.Core/Telemetry/CarrotActivityFactory.cs
@@ -3,17 +3,13 @@ using CarrotMQ.Core.Configuration;
 using CarrotMQ.Core.Protocol;
 using Microsoft.Extensions.Options;
 
-namespace CarrotMQ.Core.Tracing;
+namespace CarrotMQ.Core.Telemetry;
 
 /// <summary>
 /// Factory for creating <see cref="Activity" /> for CarrotMQ tracing
 /// </summary>
 public static class CarrotActivityFactory
 {
-    /// <summary>
-    /// Name of the ActivitySource object used for tracing with CarrotMQ.RabbitMQ
-    /// </summary>
-    public const string TracingActivitySourceName = "CarrotMQ.RabbitMQ";
     /// <summary>
     /// Key for remote service name in the activity tags.
     /// </summary>
@@ -32,7 +28,7 @@ public static class CarrotActivityFactory
     /// <summary>
     /// The <see cref="System.Diagnostics.ActivitySource" /> used for CarrotMQ tracing.
     /// </summary>
-    private static readonly ActivitySource ActivitySource = new(TracingActivitySourceName);
+    private static readonly ActivitySource ActivitySource = new(Names.CarrotActivitySourceName);
 
     /// <summary>
     /// Creates a new Consumer tracing activity.

--- a/CarrotMQ.Core/Telemetry/CarrotMetricsRecorder.cs
+++ b/CarrotMQ.Core/Telemetry/CarrotMetricsRecorder.cs
@@ -6,18 +6,13 @@ using CarrotMQ.Core.MessageProcessing.Delivery;
 using System.Diagnostics;
 #endif
 
-namespace CarrotMQ.Core.Tracing;
+namespace CarrotMQ.Core.Telemetry;
 
 /// <summary>
 /// Class for recording metrics related to CarrotMQ processing, such as request duration and message delivery status.
 /// </summary>
 internal sealed class CarrotMetricsRecorder : ICarrotMetricsRecorder
 {
-    /// <summary>
-    /// Constant representing the name of the meter used for CarrotMQ metrics.
-    /// </summary>
-    public const string MeterName = "CarrotMQ.RabbitMQ.CarrotMeter";
-
     /// <summary>
     /// Counter to track the number of active requests.
     /// </summary>
@@ -54,13 +49,13 @@ internal sealed class CarrotMetricsRecorder : ICarrotMetricsRecorder
     /// <param name="meterFactory">Factory for creating meters.</param>
     public CarrotMetricsRecorder(IMeterFactory meterFactory)
     {
-        _meter = meterFactory.Create(MeterName);
+        _meter = meterFactory.Create(Names.CarrotMeterName);
 
-        _requestDurationHistogram = _meter.CreateHistogram<double>("carrotmq-rabbitmq-request-duration-ms");
-        _activeRequestsCounter = _meter.CreateUpDownCounter<long>("carrotmq-rabbitmq-active-requests-counter");
-        _requestsCounter = _meter.CreateCounter<long>("carrotmq-rabbitmq-request-counter");
-        _responseStatusCounter = _meter.CreateCounter<long>("carrotmq-rabbitmq-response-counter");
-        _messageDeliveryCounter = _meter.CreateCounter<long>("carrotmq-rabbitmq-message-delivery-counter");
+        _requestDurationHistogram = _meter.CreateHistogram<double>("carrotmq-request-duration-ms");
+        _activeRequestsCounter = _meter.CreateUpDownCounter<long>("carrotmq-active-requests-counter");
+        _requestsCounter = _meter.CreateCounter<long>("carrotmq-request-counter");
+        _responseStatusCounter = _meter.CreateCounter<long>("carrotmq-response-counter");
+        _messageDeliveryCounter = _meter.CreateCounter<long>("carrotmq-message-delivery-counter");
     }
 
     /// <inheritdoc />

--- a/CarrotMQ.Core/Telemetry/ICarrotMetricsRecorder.cs
+++ b/CarrotMQ.Core/Telemetry/ICarrotMetricsRecorder.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using CarrotMQ.Core.MessageProcessing.Delivery;
 
-namespace CarrotMQ.Core.Tracing;
+namespace CarrotMQ.Core.Telemetry;
 
 /// <summary>
 /// Interface for recording metrics related to CarrotMQ processing, such as request duration and message delivery status.

--- a/CarrotMQ.Core/Telemetry/Names.cs
+++ b/CarrotMQ.Core/Telemetry/Names.cs
@@ -1,0 +1,14 @@
+﻿namespace CarrotMQ.Core.Telemetry;
+
+///
+public static class Names
+{
+    /// <summary>
+    /// Name of the meter used for CarrotMQ metrics.
+    /// </summary>
+    public const string CarrotMeterName = "CarrotMQ.Meter";
+    /// <summary>
+    /// Name of the ActivitySource object used for tracing with CarrotMQ
+    /// </summary>
+    public const string CarrotActivitySourceName = "CarrotMQ.ActivitySource";
+}

--- a/CarrotMQ.RabbitMQ.Test/CarrotConsumerTests.cs
+++ b/CarrotMQ.RabbitMQ.Test/CarrotConsumerTests.cs
@@ -3,7 +3,7 @@ using CarrotMQ.Core.Configuration;
 using CarrotMQ.Core.MessageProcessing;
 using CarrotMQ.Core.MessageProcessing.Delivery;
 using CarrotMQ.Core.Protocol;
-using CarrotMQ.Core.Tracing;
+using CarrotMQ.Core.Telemetry;
 using CarrotMQ.RabbitMQ.Configuration.Queues;
 using CarrotMQ.RabbitMQ.Connectivity;
 using CarrotMQ.RabbitMQ.Serialization;

--- a/CarrotMQ.RabbitMQ/CarrotConsumer.cs
+++ b/CarrotMQ.RabbitMQ/CarrotConsumer.cs
@@ -9,7 +9,7 @@ using CarrotMQ.Core.Configuration;
 using CarrotMQ.Core.MessageProcessing;
 using CarrotMQ.Core.MessageProcessing.Delivery;
 using CarrotMQ.Core.Protocol;
-using CarrotMQ.Core.Tracing;
+using CarrotMQ.Core.Telemetry;
 using CarrotMQ.RabbitMQ.Configuration.Queues;
 using CarrotMQ.RabbitMQ.Connectivity;
 using CarrotMQ.RabbitMQ.MessageProcessing;

--- a/CarrotMQ.RabbitMQ/Connectivity/CarrotConsumerManager.cs
+++ b/CarrotMQ.RabbitMQ/Connectivity/CarrotConsumerManager.cs
@@ -5,7 +5,7 @@ using CarrotMQ.Core;
 using CarrotMQ.Core.Common;
 using CarrotMQ.Core.Configuration;
 using CarrotMQ.Core.MessageProcessing;
-using CarrotMQ.Core.Tracing;
+using CarrotMQ.Core.Telemetry;
 using CarrotMQ.RabbitMQ.Configuration.Exchanges;
 using CarrotMQ.RabbitMQ.Configuration.Queues;
 using CarrotMQ.RabbitMQ.Serialization;

--- a/CarrotMQ.RabbitMQ/Connectivity/RabbitTransport.cs
+++ b/CarrotMQ.RabbitMQ/Connectivity/RabbitTransport.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CarrotMQ.Core.Configuration;
 using CarrotMQ.Core.Protocol;
-using CarrotMQ.Core.Tracing;
+using CarrotMQ.Core.Telemetry;
 using CarrotMQ.RabbitMQ.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;


### PR DESCRIPTION
 - Change Namespace from Tracing to Telemetry
 - Add static Names class for Meter and Activity names