### PR TITLE
Extract message transformation int CarrotMessageBuilder

### DIFF
--- a/CarrotMQ.Core.Test/MessageEnricherTest.cs
+++ b/CarrotMQ.Core.Test/MessageEnricherTest.cs
@@ -1,6 +1,7 @@
 using CarrotMQ.Core.Configuration;
 using CarrotMQ.Core.Dto;
 using CarrotMQ.Core.MessageProcessing;
+using CarrotMQ.Core.MessageSending;
 using CarrotMQ.Core.Protocol;
 using CarrotMQ.Core.Serialization;
 using CarrotMQ.Core.Test.Helper;
@@ -288,11 +289,8 @@ public class MessageEnricherTest
 
     private ICarrotClient CreateCarrotClient(params IMessageEnricher[] messageEnrichers)
     {
-        return new CarrotClient(
-            messageEnrichers,
-            _transport,
-            new DefaultRoutingKeyResolver(),
-            _serializer);
+        var messageBuilder = new CarrotMessageBuilder(messageEnrichers, _serializer, new DefaultRoutingKeyResolver());
+        return new CarrotClient(_transport, _serializer, messageBuilder);
     }
 
     private class TestCommand : ICommand<TestCommand, TestResponse, TestQueueEndPoint>

--- a/CarrotMQ.Core/CarrotClient.cs
+++ b/CarrotMQ.Core/CarrotClient.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CarrotMQ.Core.Dto;
 using CarrotMQ.Core.Dto.Internals;
 using CarrotMQ.Core.EndPoints;
-using CarrotMQ.Core.MessageProcessing;
+using CarrotMQ.Core.MessageSending;
 using CarrotMQ.Core.Protocol;
 using CarrotMQ.Core.Serialization;
 
@@ -19,28 +17,24 @@ namespace CarrotMQ.Core;
 /// </summary>
 public sealed class CarrotClient : ICarrotClient
 {
-    private readonly IEnumerable<IMessageEnricher> _messageEnrichers;
-    private readonly IRoutingKeyResolver _routingKeyResolver;
     private readonly ICarrotSerializer _serializer;
     private readonly ITransport _transport;
+    private readonly ICarrotMessageBuilder _messageBuilder;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CarrotClient" /> class.
     /// </summary>
-    /// <param name="messageEnrichers"></param>
     /// <param name="transport">The transport mechanism for message exchange.</param>
-    /// <param name="routingKeyResolver">The resolver for routing keys.</param>
     /// <param name="serializer">The serializer for message payloads.</param>
+    /// <param name="messageBuilder">The message builder used to convert typed messages into <see cref="CarrotMessage"/>s</param>
     public CarrotClient(
-        IEnumerable<IMessageEnricher> messageEnrichers,
         ITransport transport,
-        IRoutingKeyResolver routingKeyResolver,
-        ICarrotSerializer serializer)
+        ICarrotSerializer serializer,
+        ICarrotMessageBuilder messageBuilder)
     {
-        _messageEnrichers = messageEnrichers;
         _transport = transport ?? throw new ArgumentNullException(nameof(transport));
-        _routingKeyResolver = routingKeyResolver ?? throw new ArgumentNullException(nameof(routingKeyResolver));
         _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+        _messageBuilder = messageBuilder ?? throw new ArgumentNullException(nameof(messageBuilder));
     }
 
     /// <inheritdoc />
@@ -50,7 +44,8 @@ public sealed class CarrotClient : ICarrotClient
         CancellationToken cancellationToken = default)
         where TEvent : ICustomRoutingEvent<TEvent>
     {
-        var message = await BuildCarrotMessageAsync(@event, @event.Exchange, @event.RoutingKey, new NoReplyEndPoint(), context, cancellationToken)
+        var message = await _messageBuilder
+            .BuildCarrotMessageAsync(@event, @event.Exchange, @event.RoutingKey, new NoReplyEndPoint(), context, cancellationToken)
             .ConfigureAwait(false);
 
         await SendAsync(message, cancellationToken).ConfigureAwait(false);
@@ -64,7 +59,9 @@ public sealed class CarrotClient : ICarrotClient
         where TEvent : IEvent<TEvent, TExchangeEndPoint>
         where TExchangeEndPoint : ExchangeEndPoint, new()
     {
-        var message = await BuildCarrotMessageAsync(@event, new NoReplyEndPoint(), context, cancellationToken).ConfigureAwait(false);
+        CarrotMessage message = await _messageBuilder
+            .BuildCarrotMessageAsync(@event, context, cancellationToken)
+            .ConfigureAwait(false);
 
         await SendAsync(message, cancellationToken).ConfigureAwait(false);
     }
@@ -78,7 +75,9 @@ public sealed class CarrotClient : ICarrotClient
         where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        var message = await BuildSendReceiveMessageAsync(command, context, cancellationToken).ConfigureAwait(false);
+        var message = await _messageBuilder
+            .BuildCarrotMessageAsync(command, context, cancellationToken)
+            .ConfigureAwait(false);
 
         return await SendReceiveAsync<TCommand, TResponse, TEndPointDefinition>(message, cancellationToken)
             .ConfigureAwait(false);
@@ -93,7 +92,9 @@ public sealed class CarrotClient : ICarrotClient
         where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        var message = await BuildSendReceiveMessageAsync(query, context, cancellationToken).ConfigureAwait(false);
+        var message = await _messageBuilder
+            .BuildCarrotMessageAsync(query, context, cancellationToken)
+            .ConfigureAwait(false);
 
         return await SendReceiveAsync<TQuery, TResponse, TEndPointDefinition>(message, cancellationToken)
             .ConfigureAwait(false);
@@ -110,9 +111,9 @@ public sealed class CarrotClient : ICarrotClient
         where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        var message = await BuildCarrotMessageAsync(command, replyEndPoint ?? new NoReplyEndPoint(), context, cancellationToken)
+        var message = await _messageBuilder
+            .BuildCarrotMessageAsync(command, replyEndPoint, context, correlationId, cancellationToken)
             .ConfigureAwait(false);
-        message.Header.CorrelationId = correlationId;
 
         await SendAsync(message, cancellationToken).ConfigureAwait(false);
     }
@@ -128,88 +129,11 @@ public sealed class CarrotClient : ICarrotClient
         where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        var message = await BuildCarrotMessageAsync(query, replyEndPoint, context, cancellationToken).ConfigureAwait(false);
-        message.Header.CorrelationId = correlationId;
+        CarrotMessage message = await _messageBuilder
+            .BuildCarrotMessageAsync(query, replyEndPoint, context, correlationId, cancellationToken)
+            .ConfigureAwait(false);
 
         await SendAsync(message, cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task<CarrotMessage> BuildSendReceiveMessageAsync<TRequest, TResponse, TEndPointDefinition>(
-        _IRequest<TRequest, TResponse, TEndPointDefinition> request,
-        Context? context,
-        CancellationToken cancellationToken)
-        where TResponse : class
-        where TRequest : _IRequest<TRequest, TResponse, TEndPointDefinition>
-        where TEndPointDefinition : EndPointBase, new()
-    {
-        var message = await BuildCarrotMessageAsync(request, new DirectReplyEndPoint(), context, cancellationToken).ConfigureAwait(false);
-        message.Header.CorrelationId = Guid.NewGuid();
-        if (message.Header.MessageProperties.Ttl == null)
-        {
-            var messageProperties = message.Header.MessageProperties;
-            messageProperties.Ttl = 5_000;
-            message.Header.MessageProperties = messageProperties;
-        }
-
-        return message;
-    }
-
-    private Task<CarrotMessage> BuildCarrotMessageAsync<TRequest, TResponse, TEndPointDefinition>(
-        _IMessage<TRequest, TResponse, TEndPointDefinition> request,
-        ReplyEndPointBase replyEndPoint,
-        Context? context,
-        CancellationToken cancellationToken)
-        where TResponse : class
-        where TRequest : _IMessage<TRequest, TResponse, TEndPointDefinition>
-        where TEndPointDefinition : EndPointBase, new()
-    {
-        var requestEndPoint = new TEndPointDefinition();
-        var exchange = requestEndPoint.Exchange;
-        var routingKey = requestEndPoint.GetRoutingKey<TRequest>(_routingKeyResolver);
-
-        return BuildCarrotMessageAsync(request, exchange, routingKey, replyEndPoint, context, cancellationToken);
-    }
-
-    private async Task<CarrotMessage> BuildCarrotMessageAsync<TRequest, TResponse>(
-        _IMessage<TRequest, TResponse> request,
-        string exchange,
-        string routingKey,
-        ReplyEndPointBase replyEndPoint,
-        Context? context,
-        CancellationToken cancellationToken)
-        where TResponse : class
-        where TRequest : _IMessage<TRequest, TResponse>
-    {
-        var ctx = context ?? new Context();
-
-        foreach (var enricher in _messageEnrichers)
-        {
-            await enricher.EnrichMessageAsync(request, ctx, cancellationToken).ConfigureAwait(false);
-        }
-
-        var header = new CarrotHeader
-        {
-            MessageId = Guid.NewGuid(),
-            CalledMethod = request.GetType().FullName
-                ?? throw new ArgumentException($"Can not get FullName of type {nameof(request)}", nameof(request)),
-            Exchange = exchange,
-            RoutingKey = routingKey,
-            InitialUserName = ctx.InitialUserName,
-            InitialServiceName = ctx.InitialServiceName,
-            MessageProperties = ctx.MessageProperties,
-            CustomHeader = ctx.CustomHeader.ToDictionary(
-                entry => entry.Key,
-                entry => entry.Value),
-            ReplyExchange = replyEndPoint.Exchange,
-            ReplyRoutingKey = replyEndPoint.RoutingKey,
-            IncludeRequestPayloadInResponse = replyEndPoint.IncludeRequestPayloadInResponse
-        };
-
-        var messagePayload = _serializer.Serialize(request);
-
-        var message = new CarrotMessage(header, messagePayload);
-
-        return message;
     }
 
     private async Task<CarrotResponse<TRequest, TResponse>> SendReceiveAsync<TRequest, TResponse, TEndPointDefinition>(

--- a/CarrotMQ.Core/CarrotClient.cs
+++ b/CarrotMQ.Core/CarrotClient.cs
@@ -17,16 +17,16 @@ namespace CarrotMQ.Core;
 /// </summary>
 public sealed class CarrotClient : ICarrotClient
 {
+    private readonly ICarrotMessageBuilder _messageBuilder;
     private readonly ICarrotSerializer _serializer;
     private readonly ITransport _transport;
-    private readonly ICarrotMessageBuilder _messageBuilder;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CarrotClient" /> class.
     /// </summary>
     /// <param name="transport">The transport mechanism for message exchange.</param>
     /// <param name="serializer">The serializer for message payloads.</param>
-    /// <param name="messageBuilder">The message builder used to convert typed messages into <see cref="CarrotMessage"/>s</param>
+    /// <param name="messageBuilder">The message builder used to convert typed messages into <see cref="CarrotMessage" />s</param>
     public CarrotClient(
         ITransport transport,
         ICarrotSerializer serializer,
@@ -44,7 +44,7 @@ public sealed class CarrotClient : ICarrotClient
         CancellationToken cancellationToken = default)
         where TEvent : ICustomRoutingEvent<TEvent>
     {
-        var message = await _messageBuilder
+        CarrotMessage message = await _messageBuilder
             .BuildCarrotMessageAsync(@event, @event.Exchange, @event.RoutingKey, new NoReplyEndPoint(), context, cancellationToken)
             .ConfigureAwait(false);
 
@@ -75,7 +75,7 @@ public sealed class CarrotClient : ICarrotClient
         where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        var message = await _messageBuilder
+        CarrotMessage message = await _messageBuilder
             .BuildCarrotMessageAsync(command, context, cancellationToken)
             .ConfigureAwait(false);
 
@@ -92,7 +92,7 @@ public sealed class CarrotClient : ICarrotClient
         where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        var message = await _messageBuilder
+        CarrotMessage message = await _messageBuilder
             .BuildCarrotMessageAsync(query, context, cancellationToken)
             .ConfigureAwait(false);
 
@@ -111,7 +111,7 @@ public sealed class CarrotClient : ICarrotClient
         where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        var message = await _messageBuilder
+        CarrotMessage message = await _messageBuilder
             .BuildCarrotMessageAsync(command, replyEndPoint, context, correlationId, cancellationToken)
             .ConfigureAwait(false);
 

--- a/CarrotMQ.Core/Configuration/ServiceCollectionExtensions.cs
+++ b/CarrotMQ.Core/Configuration/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using CarrotMQ.Core.MessageProcessing;
 using CarrotMQ.Core.MessageProcessing.Middleware;
+using CarrotMQ.Core.MessageSending;
 using CarrotMQ.Core.Serialization;
 using CarrotMQ.Core.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
@@ -42,6 +43,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IResponseSender, ResponseSender>();
         services.AddSingleton<ICarrotMetricsRecorder, CarrotMetricsRecorder>();
 
+        services.TryAddTransient<ICarrotMessageBuilder, CarrotMessageBuilder>();
         services.TryAddScoped<IMiddlewareProcessor, MiddlewareProcessor>();
         services.TryAddSingleton<ICarrotSerializer, DefaultCarrotSerializer>();
         services.TryAddSingleton<IDependencyInjector, DependencyInjector>();

--- a/CarrotMQ.Core/MessageProcessing/DependencyInjector.cs
+++ b/CarrotMQ.Core/MessageProcessing/DependencyInjector.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using CarrotMQ.Core.Dto.Internals;
 using CarrotMQ.Core.Handlers;
 using CarrotMQ.Core.MessageProcessing.Middleware;
-using CarrotMQ.Core.Protocol;
 using CarrotMQ.Core.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/CarrotMQ.Core/MessageProcessing/IDependencyInjector.cs
+++ b/CarrotMQ.Core/MessageProcessing/IDependencyInjector.cs
@@ -2,7 +2,6 @@
 using CarrotMQ.Core.Dto.Internals;
 using CarrotMQ.Core.Handlers;
 using CarrotMQ.Core.MessageProcessing.Middleware;
-using CarrotMQ.Core.Protocol;
 using CarrotMQ.Core.Serialization;
 
 namespace CarrotMQ.Core.MessageProcessing;

--- a/CarrotMQ.Core/MessageSending/CarrotMessageBuilder.cs
+++ b/CarrotMQ.Core/MessageSending/CarrotMessageBuilder.cs
@@ -1,0 +1,140 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CarrotMQ.Core.Dto;
+using CarrotMQ.Core.Dto.Internals;
+using CarrotMQ.Core.EndPoints;
+using CarrotMQ.Core.MessageProcessing;
+using CarrotMQ.Core.Protocol;
+using CarrotMQ.Core.Serialization;
+
+namespace CarrotMQ.Core.MessageSending;
+
+internal class CarrotMessageBuilder: ICarrotMessageBuilder
+{
+    private readonly IEnumerable<IMessageEnricher> _messageEnrichers;
+    private readonly ICarrotSerializer _serializer;
+    private readonly IRoutingKeyResolver _routingKeyResolver;
+
+    public CarrotMessageBuilder(
+        IEnumerable<IMessageEnricher> messageEnrichers,
+        ICarrotSerializer serializer,
+        IRoutingKeyResolver routingKeyResolver)
+    {
+        _messageEnrichers = messageEnrichers;
+        _serializer = serializer;
+        _routingKeyResolver = routingKeyResolver;
+    }
+
+    public async Task<CarrotMessage> BuildCarrotMessageAsync<TEvent, TExchangeEndPoint>(IEvent<TEvent, TExchangeEndPoint> @event, Context? context,
+        CancellationToken cancellationToken) where TEvent : IEvent<TEvent, TExchangeEndPoint>
+        where TExchangeEndPoint : ExchangeEndPoint, new()
+    {
+        var message = await BuildCarrotMessageAsync(@event, new NoReplyEndPoint(), context, cancellationToken).ConfigureAwait(false);
+        return message;
+    }
+
+    public async Task<CarrotMessage> BuildCarrotMessageAsync<TCommand, TResponse, TEndPointDefinition>(ICommand<TCommand, TResponse, TEndPointDefinition> command,
+        ReplyEndPointBase? replyEndPoint, Context? context, Guid? correlationId, CancellationToken cancellationToken)
+        where TResponse : class
+        where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
+        where TEndPointDefinition : EndPointBase, new()
+    {
+        var message = await BuildCarrotMessageAsync(command, replyEndPoint ?? new NoReplyEndPoint(), context, cancellationToken)
+            .ConfigureAwait(false);
+        message.Header.CorrelationId = correlationId;
+        return message;
+    }
+
+    public async Task<CarrotMessage> BuildCarrotMessageAsync<TQuery, TResponse, TEndPointDefinition>(IQuery<TQuery, TResponse, TEndPointDefinition> query,
+    ReplyEndPointBase replyEndPoint, Context? context, Guid? correlationId, CancellationToken cancellationToken)
+    where TResponse : class
+    where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>
+    where TEndPointDefinition : EndPointBase, new()
+    {
+        var message = await BuildCarrotMessageAsync(query, replyEndPoint, context, cancellationToken).ConfigureAwait(false);
+        message.Header.CorrelationId = correlationId;
+        return message;
+    }
+
+    public async Task<CarrotMessage> BuildCarrotMessageAsync<TRequest, TResponse, TEndPointDefinition>(
+        _IRequest<TRequest, TResponse, TEndPointDefinition> request,
+        Context? context,
+        CancellationToken cancellationToken)
+        where TResponse : class
+        where TRequest : _IRequest<TRequest, TResponse, TEndPointDefinition>
+        where TEndPointDefinition : EndPointBase, new()
+    {
+        var message = await BuildCarrotMessageAsync(request, new DirectReplyEndPoint(), context, cancellationToken).ConfigureAwait(false);
+        message.Header.CorrelationId = Guid.NewGuid();
+        if (message.Header.MessageProperties.Ttl == null)
+        {
+            var messageProperties = message.Header.MessageProperties;
+            messageProperties.Ttl = 5_000;
+            message.Header.MessageProperties = messageProperties;
+        }
+
+        return message;
+    }
+
+    private Task<CarrotMessage> BuildCarrotMessageAsync<TRequest, TResponse, TEndPointDefinition>(
+        _IMessage<TRequest, TResponse, TEndPointDefinition> request,
+        ReplyEndPointBase replyEndPoint,
+        Context? context,
+        CancellationToken cancellationToken)
+        where TResponse : class
+        where TRequest : _IMessage<TRequest, TResponse, TEndPointDefinition>
+        where TEndPointDefinition : EndPointBase, new()
+    {
+        var requestEndPoint = new TEndPointDefinition();
+        var exchange = requestEndPoint.Exchange;
+        var routingKey = requestEndPoint.GetRoutingKey<TRequest>(_routingKeyResolver);
+
+        return BuildCarrotMessageAsync(request, exchange, routingKey, replyEndPoint, context, cancellationToken);
+    }
+
+    public async Task<CarrotMessage> BuildCarrotMessageAsync<TRequest, TResponse>(
+        _IMessage<TRequest, TResponse> request,
+        string exchange,
+        string routingKey,
+        ReplyEndPointBase replyEndPoint,
+        Context? context,
+        CancellationToken cancellationToken)
+        where TResponse : class
+        where TRequest : _IMessage<TRequest, TResponse>
+    {
+        var ctx = context ?? new Context();
+
+        foreach (var enricher in _messageEnrichers)
+        {
+            await enricher.EnrichMessageAsync(request, ctx, cancellationToken).ConfigureAwait(false);
+        }
+
+        var header = new CarrotHeader
+        {
+            MessageId = Guid.NewGuid(),
+            CalledMethod = request.GetType().FullName
+                ?? throw new ArgumentException($"Can not get FullName of type {nameof(request)}", nameof(request)),
+            Exchange = exchange,
+            RoutingKey = routingKey,
+            InitialUserName = ctx.InitialUserName,
+            InitialServiceName = ctx.InitialServiceName,
+            MessageProperties = ctx.MessageProperties,
+            CustomHeader = ctx.CustomHeader.ToDictionary(
+                entry => entry.Key,
+                entry => entry.Value),
+            ReplyExchange = replyEndPoint.Exchange,
+            ReplyRoutingKey = replyEndPoint.RoutingKey,
+            IncludeRequestPayloadInResponse = replyEndPoint.IncludeRequestPayloadInResponse
+        };
+
+        var messagePayload = _serializer.Serialize(request);
+
+        var message = new CarrotMessage(header, messagePayload);
+
+        return message;
+    }
+}

--- a/CarrotMQ.Core/MessageSending/CarrotMessageBuilder.cs
+++ b/CarrotMQ.Core/MessageSending/CarrotMessageBuilder.cs
@@ -34,7 +34,7 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         CancellationToken cancellationToken) where TEvent : IEvent<TEvent, TExchangeEndPoint>
         where TExchangeEndPoint : ExchangeEndPoint, new()
     {
-        CarrotMessage message = await BuildCarrotMessageAsync(@event, new NoReplyEndPoint(), context, cancellationToken).ConfigureAwait(false);
+        CarrotMessage message = await BuildCarrotMessageInternalAsync(@event, new NoReplyEndPoint(), context, cancellationToken).ConfigureAwait(false);
 
         return message;
     }
@@ -47,7 +47,7 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         Context? context,
         CancellationToken cancellationToken) where TEvent : ICustomRoutingEvent<TEvent>
     {
-        return await BuildCarrotMessageAsyncInternal(@event, exchange, routingKey, replyEndPoint, context, cancellationToken).ConfigureAwait(false);
+        return await BuildCarrotMessageInternalAsync(@event, exchange, routingKey, replyEndPoint, context, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<CarrotMessage> BuildCarrotMessageAsync<TCommand, TResponse, TEndPointDefinition>(
@@ -60,7 +60,7 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        CarrotMessage message = await BuildCarrotMessageAsync(command, replyEndPoint ?? new NoReplyEndPoint(), context, cancellationToken)
+        CarrotMessage message = await BuildCarrotMessageInternalAsync(command, replyEndPoint ?? new NoReplyEndPoint(), context, cancellationToken)
             .ConfigureAwait(false);
         message.Header.CorrelationId = correlationId;
 
@@ -74,7 +74,7 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         where TResponse : class
         where TEndPointDefinition : EndPointBase, new()
     {
-        return await BuildCarrotMessageAsyncInternal(request, context, cancellationToken).ConfigureAwait(false);
+        return await BuildCarrotMessageInternalAsync(request, context, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<CarrotMessage> BuildCarrotMessageAsync<TQuery, TResponse, TEndPointDefinition>(
@@ -87,7 +87,7 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        CarrotMessage message = await BuildCarrotMessageAsync(query, replyEndPoint, context, cancellationToken).ConfigureAwait(false);
+        CarrotMessage message = await BuildCarrotMessageInternalAsync(query, replyEndPoint, context, cancellationToken).ConfigureAwait(false);
         message.Header.CorrelationId = correlationId;
 
         return message;
@@ -100,10 +100,10 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         where TResponse : class
         where TEndPointDefinition : EndPointBase, new()
     {
-        return await BuildCarrotMessageAsyncInternal(request, context, cancellationToken).ConfigureAwait(false);
+        return await BuildCarrotMessageInternalAsync(request, context, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<CarrotMessage> BuildCarrotMessageAsyncInternal<TRequest, TResponse, TEndPointDefinition>(
+    private async Task<CarrotMessage> BuildCarrotMessageInternalAsync<TRequest, TResponse, TEndPointDefinition>(
         _IRequest<TRequest, TResponse, TEndPointDefinition> request,
         Context? context,
         CancellationToken cancellationToken)
@@ -111,7 +111,7 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         where TRequest : _IRequest<TRequest, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        CarrotMessage message = await BuildCarrotMessageAsync(request, new DirectReplyEndPoint(), context, cancellationToken).ConfigureAwait(false);
+        CarrotMessage message = await BuildCarrotMessageInternalAsync(request, new DirectReplyEndPoint(), context, cancellationToken).ConfigureAwait(false);
         message.Header.CorrelationId = Guid.NewGuid();
         if (message.Header.MessageProperties.Ttl == null)
         {
@@ -123,7 +123,7 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         return message;
     }
 
-    private Task<CarrotMessage> BuildCarrotMessageAsync<TRequest, TResponse, TEndPointDefinition>(
+    private Task<CarrotMessage> BuildCarrotMessageInternalAsync<TRequest, TResponse, TEndPointDefinition>(
         _IMessage<TRequest, TResponse, TEndPointDefinition> request,
         ReplyEndPointBase replyEndPoint,
         Context? context,
@@ -136,10 +136,10 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         string exchange = requestEndPoint.Exchange;
         string routingKey = requestEndPoint.GetRoutingKey<TRequest>(_routingKeyResolver);
 
-        return BuildCarrotMessageAsyncInternal(request, exchange, routingKey, replyEndPoint, context, cancellationToken);
+        return BuildCarrotMessageInternalAsync(request, exchange, routingKey, replyEndPoint, context, cancellationToken);
     }
 
-    private async Task<CarrotMessage> BuildCarrotMessageAsyncInternal<TRequest, TResponse>(
+    private async Task<CarrotMessage> BuildCarrotMessageInternalAsync<TRequest, TResponse>(
         _IMessage<TRequest, TResponse> request,
         string exchange,
         string routingKey,

--- a/CarrotMQ.Core/MessageSending/ICarrotMessageBuilder.cs
+++ b/CarrotMQ.Core/MessageSending/ICarrotMessageBuilder.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using CarrotMQ.Core.Dto;
-using CarrotMQ.Core.Dto.Internals;
 using CarrotMQ.Core.EndPoints;
 using CarrotMQ.Core.Protocol;
 
@@ -23,11 +22,30 @@ public interface ICarrotMessageBuilder
         where TExchangeEndPoint : ExchangeEndPoint, new();
 
     /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    public Task<CarrotMessage> BuildCarrotMessageAsync<TEvent>(
+        ICustomRoutingEvent<TEvent> @event,
+        string exchange,
+        string routingKey,
+        ReplyEndPointBase replyEndPoint,
+        Context? context,
+        CancellationToken cancellationToken)
+        where TEvent : ICustomRoutingEvent<TEvent>;
+
+    /// <inheritdoc cref="ICarrotMessageBuilder"/>
     public Task<CarrotMessage> BuildCarrotMessageAsync<TCommand, TResponse, TEndPointDefinition>(
         ICommand<TCommand, TResponse, TEndPointDefinition> command,
         ReplyEndPointBase? replyEndPoint,
         Context? context,
         Guid? correlationId,
+        CancellationToken cancellationToken)
+        where TResponse : class
+        where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
+        where TEndPointDefinition : EndPointBase, new();
+
+    /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    public Task<CarrotMessage> BuildCarrotMessageAsync<TCommand, TResponse, TEndPointDefinition>(
+        ICommand<TCommand, TResponse, TEndPointDefinition> request,
+        Context? context,
         CancellationToken cancellationToken)
         where TResponse : class
         where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
@@ -45,22 +63,11 @@ public interface ICarrotMessageBuilder
         where TEndPointDefinition : EndPointBase, new();
 
     /// <inheritdoc cref="ICarrotMessageBuilder"/>
-    public Task<CarrotMessage> BuildCarrotMessageAsync<TRequest, TResponse, TEndPointDefinition>(
-        _IRequest<TRequest, TResponse, TEndPointDefinition> request,
+    public Task<CarrotMessage> BuildCarrotMessageAsync<TQuery, TResponse, TEndPointDefinition>(
+        IQuery<TQuery, TResponse, TEndPointDefinition> request,
         Context? context,
         CancellationToken cancellationToken)
         where TResponse : class
-        where TRequest : _IRequest<TRequest, TResponse, TEndPointDefinition>
+        where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new();
-
-    /// <inheritdoc cref="ICarrotMessageBuilder"/>
-    public Task<CarrotMessage> BuildCarrotMessageAsync<TRequest, TResponse>(
-        _IMessage<TRequest, TResponse> request,
-        string exchange,
-        string routingKey,
-        ReplyEndPointBase replyEndPoint,
-        Context? context,
-        CancellationToken cancellationToken)
-        where TResponse : class
-        where TRequest : _IMessage<TRequest, TResponse>;
 }

--- a/CarrotMQ.Core/MessageSending/ICarrotMessageBuilder.cs
+++ b/CarrotMQ.Core/MessageSending/ICarrotMessageBuilder.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CarrotMQ.Core.Dto;
+using CarrotMQ.Core.Dto.Internals;
+using CarrotMQ.Core.EndPoints;
+using CarrotMQ.Core.Protocol;
+
+namespace CarrotMQ.Core.MessageSending;
+
+/// <summary>
+/// Creates a <see cref="CarrotMessage" /> from the strongly typed message.
+/// It also invokes the <see cref="IMessageEnricher" />s.
+/// The resulting messages are ready to be passed to the <see cref="ITransport" /> for sending.
+/// </summary>
+public interface ICarrotMessageBuilder
+{
+    /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    public Task<CarrotMessage> BuildCarrotMessageAsync<TEvent, TExchangeEndPoint>(
+        IEvent<TEvent, TExchangeEndPoint> @event,
+        Context? context,
+        CancellationToken cancellationToken) where TEvent : IEvent<TEvent, TExchangeEndPoint>
+        where TExchangeEndPoint : ExchangeEndPoint, new();
+
+    /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    public Task<CarrotMessage> BuildCarrotMessageAsync<TCommand, TResponse, TEndPointDefinition>(
+        ICommand<TCommand, TResponse, TEndPointDefinition> command,
+        ReplyEndPointBase? replyEndPoint,
+        Context? context,
+        Guid? correlationId,
+        CancellationToken cancellationToken)
+        where TResponse : class
+        where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
+        where TEndPointDefinition : EndPointBase, new();
+
+    /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    public Task<CarrotMessage> BuildCarrotMessageAsync<TQuery, TResponse, TEndPointDefinition>(
+        IQuery<TQuery, TResponse, TEndPointDefinition> query,
+        ReplyEndPointBase replyEndPoint,
+        Context? context,
+        Guid? correlationId,
+        CancellationToken cancellationToken)
+        where TResponse : class
+        where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>
+        where TEndPointDefinition : EndPointBase, new();
+
+    /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    public Task<CarrotMessage> BuildCarrotMessageAsync<TRequest, TResponse, TEndPointDefinition>(
+        _IRequest<TRequest, TResponse, TEndPointDefinition> request,
+        Context? context,
+        CancellationToken cancellationToken)
+        where TResponse : class
+        where TRequest : _IRequest<TRequest, TResponse, TEndPointDefinition>
+        where TEndPointDefinition : EndPointBase, new();
+
+    /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    public Task<CarrotMessage> BuildCarrotMessageAsync<TRequest, TResponse>(
+        _IMessage<TRequest, TResponse> request,
+        string exchange,
+        string routingKey,
+        ReplyEndPointBase replyEndPoint,
+        Context? context,
+        CancellationToken cancellationToken)
+        where TResponse : class
+        where TRequest : _IMessage<TRequest, TResponse>;
+}

--- a/CarrotMQ.sln.DotSettings
+++ b/CarrotMQ.sln.DotSettings
@@ -80,4 +80,6 @@
   &lt;/TypePattern&gt;&#xD;
 &lt;/Patterns&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002EMemberReordering_002EMigrations_002ECSharpFileLayoutPatternRemoveIsAttributeUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=enricher/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enrichers/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>


### PR DESCRIPTION
Extract the conversion of strongly typed messages into CarrotMesssages. This enables users to intercept the messages in their transformed form before they are being sent (e.g. to implement a transactional outbox).