### PR TITLE
Separate Context and MessageProperties.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,20 +1,9 @@
+
+# All files
 [*]
 indent_size = 4
 indent_style = space
 tab_width = 4
-
-MA0048.only_validate_first_type = true
-dotnet_diagnostic.MA0008.severity = none
-dotnet_diagnostic.MA0012.severity = none
-dotnet_diagnostic.MA0091.severity = suggestion
-dotnet_diagnostic.MA0002.severity = suggestion
-dotnet_diagnostic.MA0051.severity = suggestion
-dotnet_diagnostic.MA0011.severity = suggestion
-dotnet_diagnostic.MA0046.severity = none
-dotnet_diagnostic.MA0132.severity = none
-MA0051.maximum_lines_per_method = 60
-MA0051.maximum_statements_per_method = 40
-MA0051.skip_local_functions = false # skip local functions when counting statements
 
 csharp_indent_braces = false
 csharp_indent_labels = no_change
@@ -456,8 +445,8 @@ dotnet_style_qualification_for_property = false:warning
 dotnet_style_readonly_field = true:suggestion
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
 end_of_line = crlf
-file_header_template = # ReSharper properties
 insert_final_newline = false
+# ReSharper properties
 resharper_access_rights_in_text_highlighting = warning
 resharper_access_to_disposed_closure_highlighting = warning
 resharper_access_to_for_each_variable_in_closure_highlighting = warning
@@ -1512,10 +1501,10 @@ resharper_structured_message_template_problem_highlighting = warning
 resharper_suggest_base_type_for_parameter_highlighting = hint
 resharper_suggest_base_type_for_parameter_in_constructor_highlighting = hint
 resharper_suggest_discard_declaration_var_style_highlighting = hint
-resharper_suggest_var_or_type_built_in_types_highlighting = hint
-resharper_suggest_var_or_type_deconstruction_declarations_highlighting = hint
-resharper_suggest_var_or_type_elsewhere_highlighting = hint
-resharper_suggest_var_or_type_simple_types_highlighting = hint
+resharper_suggest_var_or_type_built_in_types_highlighting = none
+resharper_suggest_var_or_type_deconstruction_declarations_highlighting = none
+resharper_suggest_var_or_type_elsewhere_highlighting = none
+resharper_suggest_var_or_type_simple_types_highlighting = none
 resharper_support_vs_event_naming_pattern = true
 resharper_suppress_nullable_warning_expression_as_inverted_is_expression_highlighting = warning
 resharper_suspicious_lock_over_synchronization_primitive_highlighting = warning
@@ -1874,3 +1863,12 @@ resharper_xmldoc_wrap_tags_and_pi = true
 resharper_xmldoc_wrap_text = true
 resharper_xunit_xunit_test_with_console_output_highlighting = warning
 resharper_zero_index_from_end_highlighting = warning
+
+# Generated files
+[*.{g.cs,Designer.cs}]
+dotnet_diagnostic.cs1591.severity = none
+
+# YAML Files
+[*.{yml,yaml}]
+indent_size = 2
+tab_width = 2

--- a/CarrotMQ.Core.Test/CarrotClientHeaderTests.cs
+++ b/CarrotMQ.Core.Test/CarrotClientHeaderTests.cs
@@ -62,7 +62,7 @@ public class CarrotClientHeaderTests
     {
         await _carrotClient.PublishAsync(_eventDto);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -79,7 +79,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.PublishAsync(_eventDto, context);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -96,7 +96,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.PublishAsync(_eventDto, context);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.AreEqual(UserName, resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -113,7 +113,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.PublishAsync(_eventDto, context);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.AreEqual(ServiceName, resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -128,7 +128,7 @@ public class CarrotClientHeaderTests
     {
         await _carrotClient.PublishAsync(_eventDto, messageProperties: new MessageProperties { PublisherConfirm = false });
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -145,7 +145,7 @@ public class CarrotClientHeaderTests
     {
         await _carrotClient.PublishAsync(_eventDto, messageProperties: new MessageProperties { Ttl = ttl });
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -160,7 +160,7 @@ public class CarrotClientHeaderTests
     {
         await _carrotClient.PublishAsync(_eventDto, messageProperties: new MessageProperties { Priority = 2 });
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -175,7 +175,7 @@ public class CarrotClientHeaderTests
     {
         await _carrotClient.PublishAsync(_eventDto, messageProperties: new MessageProperties { Persistent = true });
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -193,7 +193,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.PublishAsync(dto, context);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         Assert.AreEqual(UserName, resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.AreEqual(typeof(CustomRoutingKeyDto).FullName, resultHeader.CalledMethod, nameof(resultHeader.CalledMethod));
         Assert.AreEqual(CustomRoutingKeyDto.CustomExchange, resultHeader.Exchange, nameof(resultHeader.Exchange));
@@ -214,7 +214,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.SendAsync(_queryDto, replyEndpoint, context, correlationId: correlationId);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         Assert.AreEqual(UserName, resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.AreEqual(typeof(TestDto).FullName, resultHeader.CalledMethod, nameof(resultHeader.CalledMethod));
         Assert.AreEqual(string.Empty, resultHeader.Exchange, nameof(resultHeader.Exchange));
@@ -235,7 +235,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.SendAsync(_commandDto, replyEndpoint, context, correlationId: correlationId);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         Assert.AreEqual(UserName, resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.AreEqual(typeof(TestDto).FullName, resultHeader.CalledMethod, nameof(resultHeader.CalledMethod));
         Assert.AreEqual(string.Empty, resultHeader.Exchange, nameof(resultHeader.Exchange));
@@ -255,7 +255,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.SendAsync(_queryDto, replyEndpoint, context);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         Assert.IsNull(resultHeader.CorrelationId, nameof(resultHeader.CorrelationId));
     }
 
@@ -266,7 +266,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.SendAsync(_commandDto, context: context);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         Assert.IsNull(resultHeader.CorrelationId, nameof(resultHeader.CorrelationId));
     }
 
@@ -277,7 +277,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.SendAsync(_commandDto, context: context);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         Assert.AreEqual(string.Empty, resultHeader.ReplyExchange, nameof(resultHeader.ReplyExchange));
         Assert.AreEqual(string.Empty, resultHeader.ReplyRoutingKey, nameof(resultHeader.ReplyRoutingKey));
     }
@@ -293,7 +293,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.SendAsync(_queryDto, replyEndpoint);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         Assert.AreEqual(includePayload, resultHeader.IncludeRequestPayloadInResponse, nameof(resultHeader.IncludeRequestPayloadInResponse));
     }
 
@@ -304,7 +304,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.SendReceiveAsync(_commandDto, context);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         Assert.AreEqual(5_000, resultHeader.MessageProperties.Ttl, nameof(resultHeader.MessageProperties.Ttl));
     }
 
@@ -313,7 +313,7 @@ public class CarrotClientHeaderTests
     {
         await _carrotClient.SendReceiveAsync(_commandDto);
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         Assert.AreEqual(5_000, resultHeader.MessageProperties.Ttl, nameof(resultHeader.MessageProperties.Ttl));
     }
 
@@ -324,7 +324,7 @@ public class CarrotClientHeaderTests
     {
         await _carrotClient.SendReceiveAsync(_commandDto, messageProperties: new MessageProperties { Ttl = ttl });
 
-        CarrotHeader resultHeader = _resultingMessage.Header;
+        var resultHeader = _resultingMessage.Header;
         Assert.AreEqual(ttl, resultHeader.MessageProperties.Ttl, nameof(resultHeader.MessageProperties.Ttl));
     }
 

--- a/CarrotMQ.Core.Test/CarrotClientHeaderTests.cs
+++ b/CarrotMQ.Core.Test/CarrotClientHeaderTests.cs
@@ -62,7 +62,7 @@ public class CarrotClientHeaderTests
     {
         await _carrotClient.PublishAsync(_eventDto);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -79,7 +79,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.PublishAsync(_eventDto, context);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -96,7 +96,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.PublishAsync(_eventDto, context);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.AreEqual(UserName, resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -113,7 +113,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.PublishAsync(_eventDto, context);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.AreEqual(ServiceName, resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -126,11 +126,9 @@ public class CarrotClientHeaderTests
     [TestMethod]
     public async Task PublishWithoutConfirm()
     {
-        var context = new Context(messageProperties: new MessageProperties { PublisherConfirm = false });
+        await _carrotClient.PublishAsync(_eventDto, messageProperties: new MessageProperties { PublisherConfirm = false });
 
-        await _carrotClient.PublishAsync(_eventDto, context);
-
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -145,11 +143,9 @@ public class CarrotClientHeaderTests
     [TestMethod]
     public async Task PublishWithTtl(int ttl)
     {
-        var context = new Context(messageProperties: new MessageProperties { Ttl = ttl });
+        await _carrotClient.PublishAsync(_eventDto, messageProperties: new MessageProperties { Ttl = ttl });
 
-        await _carrotClient.PublishAsync(_eventDto, context);
-
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -162,11 +158,9 @@ public class CarrotClientHeaderTests
     [TestMethod]
     public async Task PublishWithPriority()
     {
-        var context = new Context(messageProperties: new MessageProperties { Priority = 2 });
+        await _carrotClient.PublishAsync(_eventDto, messageProperties: new MessageProperties { Priority = 2 });
 
-        await _carrotClient.PublishAsync(_eventDto, context);
-
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -179,11 +173,9 @@ public class CarrotClientHeaderTests
     [TestMethod]
     public async Task PublishWithPersistent()
     {
-        var context = new Context(messageProperties: new MessageProperties { Persistent = true });
+        await _carrotClient.PublishAsync(_eventDto, messageProperties: new MessageProperties { Persistent = true });
 
-        await _carrotClient.PublishAsync(_eventDto, context);
-
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         AssertGeneralPublishCarrotHeaderProperties(resultHeader);
         Assert.IsNull(resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.IsNull(resultHeader.InitialServiceName, nameof(resultHeader.InitialServiceName));
@@ -201,7 +193,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.PublishAsync(dto, context);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         Assert.AreEqual(UserName, resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.AreEqual(typeof(CustomRoutingKeyDto).FullName, resultHeader.CalledMethod, nameof(resultHeader.CalledMethod));
         Assert.AreEqual(CustomRoutingKeyDto.CustomExchange, resultHeader.Exchange, nameof(resultHeader.Exchange));
@@ -220,9 +212,9 @@ public class CarrotClientHeaderTests
         var replyEndpoint = new ExchangeReplyEndPoint(replyExchange, replyRoutingKey);
         var context = new Context(UserName);
 
-        await _carrotClient.SendAsync(_queryDto, replyEndpoint, context, correlationId);
+        await _carrotClient.SendAsync(_queryDto, replyEndpoint, context, correlationId: correlationId);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         Assert.AreEqual(UserName, resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.AreEqual(typeof(TestDto).FullName, resultHeader.CalledMethod, nameof(resultHeader.CalledMethod));
         Assert.AreEqual(string.Empty, resultHeader.Exchange, nameof(resultHeader.Exchange));
@@ -241,9 +233,9 @@ public class CarrotClientHeaderTests
         var replyEndpoint = new QueueReplyEndPoint(replyQueue);
         var context = new Context(UserName);
 
-        await _carrotClient.SendAsync(_commandDto, replyEndpoint, context, correlationId);
+        await _carrotClient.SendAsync(_commandDto, replyEndpoint, context, correlationId: correlationId);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         Assert.AreEqual(UserName, resultHeader.InitialUserName, nameof(resultHeader.InitialUserName));
         Assert.AreEqual(typeof(TestDto).FullName, resultHeader.CalledMethod, nameof(resultHeader.CalledMethod));
         Assert.AreEqual(string.Empty, resultHeader.Exchange, nameof(resultHeader.Exchange));
@@ -263,7 +255,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.SendAsync(_queryDto, replyEndpoint, context);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         Assert.IsNull(resultHeader.CorrelationId, nameof(resultHeader.CorrelationId));
     }
 
@@ -274,7 +266,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.SendAsync(_commandDto, context: context);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         Assert.IsNull(resultHeader.CorrelationId, nameof(resultHeader.CorrelationId));
     }
 
@@ -285,7 +277,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.SendAsync(_commandDto, context: context);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         Assert.AreEqual(string.Empty, resultHeader.ReplyExchange, nameof(resultHeader.ReplyExchange));
         Assert.AreEqual(string.Empty, resultHeader.ReplyRoutingKey, nameof(resultHeader.ReplyRoutingKey));
     }
@@ -301,7 +293,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.SendAsync(_queryDto, replyEndpoint);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         Assert.AreEqual(includePayload, resultHeader.IncludeRequestPayloadInResponse, nameof(resultHeader.IncludeRequestPayloadInResponse));
     }
 
@@ -312,7 +304,7 @@ public class CarrotClientHeaderTests
 
         await _carrotClient.SendReceiveAsync(_commandDto, context);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         Assert.AreEqual(5_000, resultHeader.MessageProperties.Ttl, nameof(resultHeader.MessageProperties.Ttl));
     }
 
@@ -321,7 +313,7 @@ public class CarrotClientHeaderTests
     {
         await _carrotClient.SendReceiveAsync(_commandDto);
 
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         Assert.AreEqual(5_000, resultHeader.MessageProperties.Ttl, nameof(resultHeader.MessageProperties.Ttl));
     }
 
@@ -330,11 +322,9 @@ public class CarrotClientHeaderTests
     [TestMethod]
     public async Task SendReceive_With_Custom_Ttl(int ttl)
     {
-        var context = new Context(ttl);
+        await _carrotClient.SendReceiveAsync(_commandDto, messageProperties: new MessageProperties { Ttl = ttl });
 
-        await _carrotClient.SendReceiveAsync(_commandDto, context);
-
-        var resultHeader = _resultingMessage.Header;
+        CarrotHeader resultHeader = _resultingMessage.Header;
         Assert.AreEqual(ttl, resultHeader.MessageProperties.Ttl, nameof(resultHeader.MessageProperties.Ttl));
     }
 

--- a/CarrotMQ.Core.Test/CarrotClientResponseTests.cs
+++ b/CarrotMQ.Core.Test/CarrotClientResponseTests.cs
@@ -52,8 +52,7 @@ public class CarrotClientResponseTests
                 });
         ICommand<TestDto, TestResponse, TestQueueEndPoint> request = new TestDto(1);
 
-        var context = new Context(1);
-        await _carrotClient.SendReceiveAsync(request, context);
+        await _carrotClient.SendReceiveAsync(request, messageProperties: new MessageProperties { Ttl = 1 });
     }
 
     [TestMethod]
@@ -109,8 +108,7 @@ public class CarrotClientResponseTests
                 async callInfo => { await Task.Delay(Timeout.InfiniteTimeSpan, callInfo.Arg<CancellationToken>()).ConfigureAwait(false); });
         ICommand<TestDto, TestResponse, TestQueueEndPoint> request = new TestDto(1);
 
-        var context = new Context(1);
-        await _carrotClient.SendAsync(request, context: context);
+        await _carrotClient.SendAsync(request, messageProperties: new MessageProperties { Ttl = 1 });
     }
 
     [TestMethod]

--- a/CarrotMQ.Core/CarrotClient.cs
+++ b/CarrotMQ.Core/CarrotClient.cs
@@ -45,9 +45,7 @@ public sealed class CarrotClient : ICarrotClient
         CancellationToken cancellationToken = default)
         where TEvent : ICustomRoutingEvent<TEvent>
     {
-        CarrotMessage message = await _messageBuilder
-            .BuildCarrotMessageAsync(@event, context, messageProperties, cancellationToken)
-            .ConfigureAwait(false);
+        var message = await _messageBuilder.BuildCarrotMessageAsync(@event, context, messageProperties, cancellationToken).ConfigureAwait(false);
 
         await SendAsync(message, cancellationToken).ConfigureAwait(false);
     }
@@ -61,9 +59,7 @@ public sealed class CarrotClient : ICarrotClient
         where TEvent : IEvent<TEvent, TExchangeEndPoint>
         where TExchangeEndPoint : ExchangeEndPoint, new()
     {
-        CarrotMessage message = await _messageBuilder
-            .BuildCarrotMessageAsync(@event, context, messageProperties, cancellationToken)
-            .ConfigureAwait(false);
+        var message = await _messageBuilder.BuildCarrotMessageAsync(@event, context, messageProperties, cancellationToken).ConfigureAwait(false);
 
         await SendAsync(message, cancellationToken).ConfigureAwait(false);
     }
@@ -78,12 +74,9 @@ public sealed class CarrotClient : ICarrotClient
         where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        CarrotMessage message = await _messageBuilder
-            .BuildCarrotMessageAsync(command, context, messageProperties, cancellationToken)
-            .ConfigureAwait(false);
+        var message = await _messageBuilder.BuildCarrotMessageAsync(command, context, messageProperties, cancellationToken).ConfigureAwait(false);
 
-        return await SendReceiveAsync<TCommand, TResponse, TEndPointDefinition>(message, cancellationToken)
-            .ConfigureAwait(false);
+        return await SendReceiveAsync<TCommand, TResponse, TEndPointDefinition>(message, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -96,12 +89,9 @@ public sealed class CarrotClient : ICarrotClient
         where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        CarrotMessage message = await _messageBuilder
-            .BuildCarrotMessageAsync(query, context, messageProperties, cancellationToken)
-            .ConfigureAwait(false);
+        var message = await _messageBuilder.BuildCarrotMessageAsync(query, context, messageProperties, cancellationToken).ConfigureAwait(false);
 
-        return await SendReceiveAsync<TQuery, TResponse, TEndPointDefinition>(message, cancellationToken)
-            .ConfigureAwait(false);
+        return await SendReceiveAsync<TQuery, TResponse, TEndPointDefinition>(message, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -116,7 +106,7 @@ public sealed class CarrotClient : ICarrotClient
         where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        CarrotMessage message = await _messageBuilder
+        var message = await _messageBuilder
             .BuildCarrotMessageAsync(command, replyEndPoint, context, messageProperties, correlationId, cancellationToken)
             .ConfigureAwait(false);
 
@@ -135,7 +125,7 @@ public sealed class CarrotClient : ICarrotClient
         where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        CarrotMessage message = await _messageBuilder
+        var message = await _messageBuilder
             .BuildCarrotMessageAsync(query, replyEndPoint, context, messageProperties, correlationId, cancellationToken)
             .ConfigureAwait(false);
 

--- a/CarrotMQ.Core/Context.cs
+++ b/CarrotMQ.Core/Context.cs
@@ -13,12 +13,10 @@ public class Context
     public Context(
         string? initialUserName = null,
         string? initialServiceName = null,
-        MessageProperties? messageProperties = null,
         IDictionary<string, string>? customHeader = null)
     {
         InitialUserName = initialUserName;
         InitialServiceName = initialServiceName;
-        MessageProperties = messageProperties ?? MessageProperties.Default;
         CustomHeader = customHeader ?? new Dictionary<string, string>();
     }
 
@@ -27,22 +25,11 @@ public class Context
     /// </summary>
     /// <param name="ttl">TTL in milliseconds to set <see cref="MessageProperties.Ttl" /></param>
     /// <param name="context">All values are copied from this context except <see cref="MessageProperties.Ttl" /></param>
-    public Context(int ttl, Context? context = null)
+    public Context(Context context)
     {
-        InitialUserName = context?.InitialUserName;
-        InitialServiceName = context?.InitialServiceName;
-        CustomHeader = context?.CustomHeader ?? new Dictionary<string, string>();
-
-        if (context != null)
-        {
-            var messageProperties = context.MessageProperties;
-            messageProperties.Ttl = ttl;
-            MessageProperties = messageProperties;
-        }
-        else
-        {
-            MessageProperties = new MessageProperties { Ttl = ttl };
-        }
+        InitialUserName = context.InitialUserName;
+        InitialServiceName = context.InitialServiceName;
+        CustomHeader = context.CustomHeader;
     }
 
     /// <summary>
@@ -54,11 +41,6 @@ public class Context
     /// Gets the name of the service or application sending the initial message.
     /// </summary>
     public string? InitialServiceName { get; }
-
-    /// <summary>
-    /// Gets the message properties. The default is <see cref="MessageProperties.Default" />
-    /// </summary>
-    public MessageProperties MessageProperties { get; }
 
     /// <summary>
     /// Additional header data, e.g. tracing ids.

--- a/CarrotMQ.Core/Handlers/ConsumerContext.cs
+++ b/CarrotMQ.Core/Handlers/ConsumerContext.cs
@@ -14,8 +14,8 @@ public sealed class ConsumerContext : Context
     /// </summary>
     /// <param name="initialUserName">See <see cref="Context.InitialUserName" />.</param>
     /// <param name="initialServiceName">See <see cref="Context.InitialServiceName" />.</param>
-    /// <param name="messageProperties">See <see cref="Context.MessageProperties" />.</param>
     /// <param name="customHeader">See <see cref="Context.CustomHeader" />.</param>
+    /// <param name="messageProperties">See <see cref="MessageProperties" />.</param>
     /// <param name="messageId">See <see cref="MessageId" />.</param>
     /// <param name="correlationId">See <see cref="CorrelationId" />.</param>
     /// <param name="createdAt">See <see cref="CreatedAt" />.</param>
@@ -26,12 +26,18 @@ public sealed class ConsumerContext : Context
         IDictionary<string, string>? customHeader,
         Guid messageId,
         Guid? correlationId,
-        DateTimeOffset createdAt) : base(initialUserName, initialServiceName, messageProperties, customHeader)
+        DateTimeOffset createdAt) : base(initialUserName, initialServiceName, customHeader)
     {
+        MessageProperties = messageProperties;
         MessageId = messageId;
         CorrelationId = correlationId;
         CreatedAt = createdAt;
     }
+
+    /// <summary>
+    /// Gets the message properties. The default is <see cref="MessageProperties.Default" />
+    /// </summary>
+    public MessageProperties MessageProperties { get; }
 
     /// <summary>
     /// Gets the unique message id.

--- a/CarrotMQ.Core/ICarrotClient.cs
+++ b/CarrotMQ.Core/ICarrotClient.cs
@@ -84,8 +84,8 @@ public interface ICarrotClient
     /// <param name="command">The command instance to be sent.</param>
     /// <param name="context">The optional context for the operation.</param>
     /// <param name="messageProperties">
-    /// The optional MessageProperties. If not specified <see cref="MessageProperties.Default" /> is used and TTL set to
-    /// 5000.
+    /// The optional MessageProperties.
+    /// If not specified <see cref="MessageProperties.Default" /> is used and TTL set to 5000.
     /// </param>
     /// <param name="cancellationToken">The cancellation token for the operation.</param>
     /// <returns>The reply to the command.</returns>
@@ -118,7 +118,10 @@ public interface ICarrotClient
     /// <typeparam name="TEndPointDefinition">The type of the endpoint definition associated with the query.</typeparam>
     /// <param name="query">The query instance to be sent.</param>
     /// <param name="context">The optional context for the operation.</param>
-    /// <param name="messageProperties">The optional MessageProperties. If not specified <see cref="MessageProperties.Default" /> is used.</param>
+    /// <param name="messageProperties">
+    /// The optional MessageProperties.
+    /// If not specified <see cref="MessageProperties.Default" /> is used and TTL set to 5000.
+    /// </param>
     /// <param name="cancellationToken">The cancellation token for the operation.</param>
     /// <returns>The reply to the query.</returns>
     /// <exception cref="ArgumentException">Thrown if the provided query has invalid properties.</exception>

--- a/CarrotMQ.Core/ICarrotClient.cs
+++ b/CarrotMQ.Core/ICarrotClient.cs
@@ -23,6 +23,7 @@ public interface ICarrotClient
     /// <typeparam name="TEvent">The type of the event to be published.</typeparam>
     /// <param name="event">The event instance to be published.</param>
     /// <param name="context">The optional context for the operation.</param>
+    /// <param name="messageProperties">The optional MessageProperties.</param>
     /// <param name="cancellationToken">The cancellation token for the operation.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <exception cref="ArgumentException">Thrown if the provided event has invalid properties.</exception>
@@ -38,6 +39,7 @@ public interface ICarrotClient
     Task PublishAsync<TEvent>(
         ICustomRoutingEvent<TEvent> @event,
         Context? context = null,
+        MessageProperties? messageProperties = null,
         CancellationToken cancellationToken = default)
         where TEvent : ICustomRoutingEvent<TEvent>;
 
@@ -50,6 +52,7 @@ public interface ICarrotClient
     /// <typeparam name="TExchangeEndPoint">The type of the exchange endpoint associated with the event.</typeparam>
     /// <param name="event">The event instance to be published.</param>
     /// <param name="context">The optional context for the operation.</param>
+    /// <param name="messageProperties">The optional MessageProperties. If not specified <see cref="MessageProperties.Default" /> is used.</param>
     /// <param name="cancellationToken">The cancellation token for the operation.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <exception cref="ArgumentException">Thrown if the provided event has invalid properties.</exception>
@@ -65,6 +68,7 @@ public interface ICarrotClient
     Task PublishAsync<TEvent, TExchangeEndPoint>(
         IEvent<TEvent, TExchangeEndPoint> @event,
         Context? context = null,
+        MessageProperties? messageProperties = null,
         CancellationToken cancellationToken = default)
         where TEvent : IEvent<TEvent, TExchangeEndPoint>
         where TExchangeEndPoint : ExchangeEndPoint, new();
@@ -79,6 +83,10 @@ public interface ICarrotClient
     /// <typeparam name="TEndPointDefinition">The type of the endpoint definition associated with the command.</typeparam>
     /// <param name="command">The command instance to be sent.</param>
     /// <param name="context">The optional context for the operation.</param>
+    /// <param name="messageProperties">
+    /// The optional MessageProperties. If not specified <see cref="MessageProperties.Default" /> is used and TTL set to
+    /// 5000.
+    /// </param>
     /// <param name="cancellationToken">The cancellation token for the operation.</param>
     /// <returns>The reply to the command.</returns>
     /// <exception cref="ArgumentException">Thrown if the provided command has invalid properties.</exception>
@@ -94,6 +102,7 @@ public interface ICarrotClient
     Task<CarrotResponse<TCommand, TResponse>> SendReceiveAsync<TCommand, TResponse, TEndPointDefinition>(
         ICommand<TCommand, TResponse, TEndPointDefinition> command,
         Context? context = null,
+        MessageProperties? messageProperties = null,
         CancellationToken cancellationToken = default)
         where TResponse : class
         where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
@@ -109,6 +118,7 @@ public interface ICarrotClient
     /// <typeparam name="TEndPointDefinition">The type of the endpoint definition associated with the query.</typeparam>
     /// <param name="query">The query instance to be sent.</param>
     /// <param name="context">The optional context for the operation.</param>
+    /// <param name="messageProperties">The optional MessageProperties. If not specified <see cref="MessageProperties.Default" /> is used.</param>
     /// <param name="cancellationToken">The cancellation token for the operation.</param>
     /// <returns>The reply to the query.</returns>
     /// <exception cref="ArgumentException">Thrown if the provided query has invalid properties.</exception>
@@ -124,6 +134,7 @@ public interface ICarrotClient
     Task<CarrotResponse<TQuery, TResponse>> SendReceiveAsync<TQuery, TResponse, TEndPointDefinition>(
         IQuery<TQuery, TResponse, TEndPointDefinition> query,
         Context? context = null,
+        MessageProperties? messageProperties = null,
         CancellationToken cancellationToken = default)
         where TResponse : class
         where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>
@@ -141,6 +152,7 @@ public interface ICarrotClient
     /// <param name="command">The command instance to be sent.</param>
     /// <param name="replyEndPoint">The optional reply endpoint for the command.</param>
     /// <param name="context">The optional context for the operation.</param>
+    /// <param name="messageProperties">The optional MessageProperties. If not specified <see cref="MessageProperties.Default" /> is used.</param>
     /// <param name="correlationId">The optional correlation ID for the operation.</param>
     /// <param name="cancellationToken">The cancellation token for the operation.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
@@ -158,6 +170,7 @@ public interface ICarrotClient
         ICommand<TCommand, TResponse, TEndPointDefinition> command,
         ReplyEndPointBase? replyEndPoint = null,
         Context? context = null,
+        MessageProperties? messageProperties = null,
         Guid? correlationId = null,
         CancellationToken cancellationToken = default)
         where TResponse : class
@@ -176,6 +189,7 @@ public interface ICarrotClient
     /// <param name="query">The query instance to be sent.</param>
     /// <param name="replyEndPoint">The reply endpoint for the query.</param>
     /// <param name="context">The optional context for the operation.</param>
+    /// <param name="messageProperties">The optional MessageProperties. If not specified <see cref="MessageProperties.Default" /> is used.</param>
     /// <param name="correlationId">The optional correlation ID for the operation.</param>
     /// <param name="cancellationToken">The cancellation token for the operation.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
@@ -193,6 +207,7 @@ public interface ICarrotClient
         IQuery<TQuery, TResponse, TEndPointDefinition> query,
         ReplyEndPointBase replyEndPoint,
         Context? context = null,
+        MessageProperties? messageProperties = null,
         Guid? correlationId = null,
         CancellationToken cancellationToken = default)
         where TResponse : class

--- a/CarrotMQ.Core/MessageSending/CarrotMessageBuilder.cs
+++ b/CarrotMQ.Core/MessageSending/CarrotMessageBuilder.cs
@@ -35,7 +35,7 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         CancellationToken cancellationToken) where TEvent : IEvent<TEvent, TExchangeEndPoint>
         where TExchangeEndPoint : ExchangeEndPoint, new()
     {
-        CarrotMessage message = await BuildCarrotMessageInternalAsync(@event, new NoReplyEndPoint(), context, messageProperties, cancellationToken)
+        var message = await BuildCarrotMessageInternalAsync(@event, new NoReplyEndPoint(), context, messageProperties, cancellationToken)
             .ConfigureAwait(false);
 
         return message;
@@ -47,7 +47,7 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         MessageProperties? messageProperties,
         CancellationToken cancellationToken) where TEvent : ICustomRoutingEvent<TEvent>
     {
-        CarrotMessage message = await BuildCarrotMessageInternalAsync(
+        var message = await BuildCarrotMessageInternalAsync(
                 @event,
                 @event.Exchange,
                 @event.RoutingKey,
@@ -71,7 +71,7 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        CarrotMessage message = await BuildCarrotMessageInternalAsync(
+        var message = await BuildCarrotMessageInternalAsync(
                 command,
                 replyEndPoint ?? new NoReplyEndPoint(),
                 context,
@@ -105,7 +105,7 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        CarrotMessage message = await BuildCarrotMessageInternalAsync(query, replyEndPoint, context, messageProperties, cancellationToken)
+        var message = await BuildCarrotMessageInternalAsync(query, replyEndPoint, context, messageProperties, cancellationToken)
             .ConfigureAwait(false);
         message.Header.CorrelationId = correlationId;
 
@@ -132,9 +132,8 @@ internal class CarrotMessageBuilder : ICarrotMessageBuilder
         where TRequest : _IRequest<TRequest, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new()
     {
-        CarrotMessage message =
-            await BuildCarrotMessageInternalAsync(request, new DirectReplyEndPoint(), context, messageProperties, cancellationToken)
-                .ConfigureAwait(false);
+        var message = await BuildCarrotMessageInternalAsync(request, new DirectReplyEndPoint(), context, messageProperties, cancellationToken)
+            .ConfigureAwait(false);
         message.Header.CorrelationId = Guid.NewGuid();
 
         return message;

--- a/CarrotMQ.Core/MessageSending/ICarrotMessageBuilder.cs
+++ b/CarrotMQ.Core/MessageSending/ICarrotMessageBuilder.cs
@@ -14,54 +14,60 @@ namespace CarrotMQ.Core.MessageSending;
 /// </summary>
 public interface ICarrotMessageBuilder
 {
-    /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    /// <inheritdoc cref="ICarrotMessageBuilder" />
     public Task<CarrotMessage> BuildCarrotMessageAsync<TEvent, TExchangeEndPoint>(
         IEvent<TEvent, TExchangeEndPoint> @event,
         Context? context,
+        MessageProperties? messageProperties,
         CancellationToken cancellationToken) where TEvent : IEvent<TEvent, TExchangeEndPoint>
         where TExchangeEndPoint : ExchangeEndPoint, new();
 
-    /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    /// <inheritdoc cref="ICarrotMessageBuilder" />
     public Task<CarrotMessage> BuildCarrotMessageAsync<TEvent>(
         ICustomRoutingEvent<TEvent> @event,
         Context? context,
+        MessageProperties? messageProperties,
         CancellationToken cancellationToken) where TEvent : ICustomRoutingEvent<TEvent>;
 
-    /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    /// <inheritdoc cref="ICarrotMessageBuilder" />
     public Task<CarrotMessage> BuildCarrotMessageAsync<TCommand, TResponse, TEndPointDefinition>(
         ICommand<TCommand, TResponse, TEndPointDefinition> command,
         ReplyEndPointBase? replyEndPoint,
         Context? context,
+        MessageProperties? messageProperties,
         Guid? correlationId,
         CancellationToken cancellationToken)
         where TResponse : class
         where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new();
 
-    /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    /// <inheritdoc cref="ICarrotMessageBuilder" />
     public Task<CarrotMessage> BuildCarrotMessageAsync<TCommand, TResponse, TEndPointDefinition>(
         ICommand<TCommand, TResponse, TEndPointDefinition> request,
         Context? context,
+        MessageProperties? messageProperties,
         CancellationToken cancellationToken)
         where TResponse : class
         where TCommand : ICommand<TCommand, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new();
 
-    /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    /// <inheritdoc cref="ICarrotMessageBuilder" />
     public Task<CarrotMessage> BuildCarrotMessageAsync<TQuery, TResponse, TEndPointDefinition>(
         IQuery<TQuery, TResponse, TEndPointDefinition> query,
         ReplyEndPointBase replyEndPoint,
         Context? context,
+        MessageProperties? messageProperties,
         Guid? correlationId,
         CancellationToken cancellationToken)
         where TResponse : class
         where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>
         where TEndPointDefinition : EndPointBase, new();
 
-    /// <inheritdoc cref="ICarrotMessageBuilder"/>
+    /// <inheritdoc cref="ICarrotMessageBuilder" />
     public Task<CarrotMessage> BuildCarrotMessageAsync<TQuery, TResponse, TEndPointDefinition>(
         IQuery<TQuery, TResponse, TEndPointDefinition> request,
         Context? context,
+        MessageProperties? messageProperties,
         CancellationToken cancellationToken)
         where TResponse : class
         where TQuery : IQuery<TQuery, TResponse, TEndPointDefinition>

--- a/CarrotMQ.RabbitMQ.Test.Integration/CommandTests/ExchangeEndPointDirectReplyCmdTest.cs
+++ b/CarrotMQ.RabbitMQ.Test.Integration/CommandTests/ExchangeEndPointDirectReplyCmdTest.cs
@@ -18,9 +18,9 @@ public class ExchangeEndPointDirectReplyCmdTest : TestBaseDirectReply
     {
         const int id = 1001;
 
-        var context = new Context(messageProperties: new MessageProperties { PublisherConfirm = publisherConfirm });
-
-        var response = await CarrotClient.SendReceiveAsync(new ExchangeEndPointCmd(id), context);
+        var response = await CarrotClient.SendReceiveAsync(
+            new ExchangeEndPointCmd(id),
+            messageProperties: new MessageProperties { PublisherConfirm = publisherConfirm });
 
         await VerifyOk(id, response, response.Content?.Id);
     }
@@ -109,7 +109,7 @@ public class ExchangeEndPointDirectReplyCmdTest : TestBaseDirectReply
                 TaskWaitDuration = TimeSpan.FromMilliseconds(timeoutMs),
                 WaitDurationCount = 2
             },
-            new Context(600));
+            messageProperties: new MessageProperties { Ttl = 600 });
 
         await VerifyOperationCanceled(id, sendTask);
     }

--- a/CarrotMQ.RabbitMQ.Test.Integration/CommandTests/ExchangeEndPointExchangeReplyCmdTest.cs
+++ b/CarrotMQ.RabbitMQ.Test.Integration/CommandTests/ExchangeEndPointExchangeReplyCmdTest.cs
@@ -17,14 +17,12 @@ public class ExchangeEndPointExchangeReplyCmdTest : TestBaseAsyncReply
     [DataRow(false)]
     public async Task ExchangeEndPoint_ExchangeReply_OK(bool publisherConfirm)
     {
-        var context = new Context(messageProperties: new MessageProperties { PublisherConfirm = publisherConfirm });
-
         const int id = 3001;
 
         await CarrotClient.SendAsync(
             new ExchangeEndPointCmd(id),
             new ExchangeReplyEndPoint(TestExchange.Name, ExchangeEndPointCmd.Response.GetRoutingKey()),
-            context);
+            messageProperties: new MessageProperties { PublisherConfirm = publisherConfirm });
 
         await VerifyOk(id);
     }

--- a/CarrotMQ.RabbitMQ.Test.Integration/CommandTests/ExchangeEndPointGenericResponseCmdTest.cs
+++ b/CarrotMQ.RabbitMQ.Test.Integration/CommandTests/ExchangeEndPointGenericResponseCmdTest.cs
@@ -18,9 +18,9 @@ public class ExchangeEndPointGenericResponseCmdTest : TestBaseDirectReply
     {
         const int id = 1001;
 
-        var context = new Context(messageProperties: new MessageProperties { PublisherConfirm = publisherConfirm });
-
-        var response = await CarrotClient.SendReceiveAsync(new ExchangeEndPointGenericResponseCmd(id), context);
+        var response = await CarrotClient.SendReceiveAsync(
+            new ExchangeEndPointGenericResponseCmd(id),
+            messageProperties: new MessageProperties { PublisherConfirm = publisherConfirm });
 
         await VerifyOk(id, response, response.Content?.InnerResponse?.Id);
     }

--- a/CarrotMQ.RabbitMQ.Test.Integration/CommandTests/QueueEndPointDirectReplyCmdTest.cs
+++ b/CarrotMQ.RabbitMQ.Test.Integration/CommandTests/QueueEndPointDirectReplyCmdTest.cs
@@ -105,7 +105,7 @@ public class QueueEndPointDirectReplyCmdTest : TestBaseDirectReply
                 TaskWaitDuration = TimeSpan.FromMilliseconds(timeoutMs),
                 WaitDurationCount = 2
             },
-            new Context(600));
+            messageProperties: new MessageProperties { Ttl = 600 });
 
         await VerifyOperationCanceled(id, sendTask);
     }

--- a/CarrotMQ.RabbitMQ.Test.Integration/ConsumerRecoveryTest.cs
+++ b/CarrotMQ.RabbitMQ.Test.Integration/ConsumerRecoveryTest.cs
@@ -24,7 +24,7 @@ public class ConsumerRecoveryTest
         await host1.WaitForConsumerHostBootstrapToCompleteAsync();
 
         // Send message (check that everything is initialized)
-        await TestBase.CarrotClient.SendReceiveAsync(new ConsumerRecoveryQuery(), new Context(1000));
+        await TestBase.CarrotClient.SendReceiveAsync(new ConsumerRecoveryQuery(), messageProperties: new MessageProperties { Ttl = 1000 });
 
         // Delete queue on which we are consuming --> Consumer should be recovered automatically
         var connection = host1.Host.Services.GetRequiredService<IBrokerConnection>();
@@ -39,7 +39,10 @@ public class ConsumerRecoveryTest
         {
             try
             {
-                r2 = await TestBase.CarrotClient.SendReceiveAsync(new ConsumerRecoveryQuery(), new Context(1000), cts.Token);
+                r2 = await TestBase.CarrotClient.SendReceiveAsync(
+                    new ConsumerRecoveryQuery(),
+                    messageProperties: new MessageProperties { Ttl = 1000 },
+                    cancellationToken: cts.Token);
             }
             catch (Exception)
             {

--- a/CarrotMQ.RabbitMQ.Test.Integration/ConsumerShutdownTest.cs
+++ b/CarrotMQ.RabbitMQ.Test.Integration/ConsumerShutdownTest.cs
@@ -26,7 +26,7 @@ public class ConsumerShutdownTest
         // Send message 1 (this message should reach ConsumerShutdownQueryHandler1 on host1)
         var sendTask1 = TestBase.CarrotClient.SendReceiveAsync(
             new ConsumerShutdownQuery { Data = $"{nameof(ConsumerShutdownTest)}_1" },
-            new Context(10000));
+            messageProperties: new MessageProperties { Ttl = 10000 });
 
         var semaphoreInjection = host1.Host.Services.GetRequiredService<ConsumerShutdownQueryHandler1.SemaphoreInjector>();
 
@@ -49,13 +49,13 @@ public class ConsumerShutdownTest
         await Task.Delay(500); // Delay to make sure the consumer on host1 has been canceled on the broker
         var r2 = await TestBase.CarrotClient.SendReceiveAsync(
             new ConsumerShutdownQuery { Data = $"{nameof(ConsumerShutdownTest)}_2" },
-            new Context(10000));
+            messageProperties: new MessageProperties { Ttl = 10000 });
         var r3 = await TestBase.CarrotClient.SendReceiveAsync(
             new ConsumerShutdownQuery { Data = $"{nameof(ConsumerShutdownTest)}_3" },
-            new Context(10000));
+            messageProperties: new MessageProperties { Ttl = 10000 });
         var r4 = await TestBase.CarrotClient.SendReceiveAsync(
             new ConsumerShutdownQuery { Data = $"{nameof(ConsumerShutdownTest)}_4" },
-            new Context(10000));
+            messageProperties: new MessageProperties { Ttl = 10000 });
 
         // Allow message 1 to finish 
         semaphoreInjection.AllowHandlerToComplete.Release();

--- a/CarrotMQ.RabbitMQ.Test.Integration/QueryTests/ExchangeEndPointDirectReplyQueryTest.cs
+++ b/CarrotMQ.RabbitMQ.Test.Integration/QueryTests/ExchangeEndPointDirectReplyQueryTest.cs
@@ -104,7 +104,7 @@ public class ExchangeEndPointDirectReplyQueryTest : TestBaseDirectReply
                 TaskWaitDuration = TimeSpan.FromMilliseconds(timeoutMs),
                 WaitDurationCount = 2
             },
-            new Context(600));
+            messageProperties: new MessageProperties { Ttl = 600 });
 
         await VerifyOperationCanceled(id, sendTask);
     }

--- a/CarrotMQ.RabbitMQ.Test.Integration/QueryTests/QueueEndPointDirectReplyQueryTest.cs
+++ b/CarrotMQ.RabbitMQ.Test.Integration/QueryTests/QueueEndPointDirectReplyQueryTest.cs
@@ -105,7 +105,7 @@ public class QueueEndPointDirectReplyQueryTest : TestBaseDirectReply
                 TaskWaitDuration = TimeSpan.FromMilliseconds(timeoutMs),
                 WaitDurationCount = 2
             },
-            new Context(600));
+            messageProperties: new MessageProperties { Ttl = 600 });
 
         await VerifyOperationCanceled(id, sendTask);
     }


### PR DESCRIPTION
- e.g. a TTL should not automatically be propagated to a following message: Command(TTL) -> Event(No TTL)
- update .editorconfig