### PR TITLE
Update nugets

### DIFF
--- a/CarrotMQ.Core.Test/CarrotMQ.Core.Test.csproj
+++ b/CarrotMQ.Core.Test/CarrotMQ.Core.Test.csproj
@@ -11,15 +11,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="meziantou.analyzer" Version="2.0.194">
+		<PackageReference Include="meziantou.analyzer" Version="2.0.211">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.10.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.10.1" />
 		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CarrotMQ.Core/CarrotMQ.Core.csproj
+++ b/CarrotMQ.Core/CarrotMQ.Core.csproj
@@ -33,11 +33,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="meziantou.analyzer" Version="2.0.194">
+        <PackageReference Include="meziantou.analyzer" Version="2.0.211">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -46,7 +46,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Text.Json" Version="9.0.4" />
+        <PackageReference Include="System.Text.Json" Version="9.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/CarrotMQ.RabbitMQ.Test.Integration/CarrotMQ.RabbitMQ.Test.Integration.csproj
+++ b/CarrotMQ.RabbitMQ.Test.Integration/CarrotMQ.RabbitMQ.Test.Integration.csproj
@@ -11,20 +11,20 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="meziantou.analyzer" Version="2.0.194">
+		<PackageReference Include="meziantou.analyzer" Version="2.0.211">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.10.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.10.1" />
 		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="NSubstitute" Version="5.3.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="Testcontainers.RabbitMq" Version="4.3.0" />
+        <PackageReference Include="Testcontainers.RabbitMq" Version="4.6.0" />
     </ItemGroup>
 
 

--- a/CarrotMQ.RabbitMQ.Test.Integration/TestHelper/TestBase.cs
+++ b/CarrotMQ.RabbitMQ.Test.Integration/TestHelper/TestBase.cs
@@ -54,7 +54,7 @@ public class TestBase
         RabbitMqContainerAmqpPort = s_rabbitContainer.GetMappedPublicPort(5672);
         RabbitMqContainerHttpPort = s_rabbitContainer.GetMappedPublicPort(15672);
 
-        RabbitMqConnectionString = $"amqp://127.0.0.1:{RabbitMqContainerAmqpPort}";
+        RabbitMqConnectionString = $"amqp://{s_rabbitContainer.Hostname}:{RabbitMqContainerAmqpPort}";
         RabbitMqVhost = $"vhost-test-{Guid.NewGuid()}";
 
         var brokerConnectionOptions = ConfigureBroker();

--- a/CarrotMQ.RabbitMQ.Test/CarrotMQ.RabbitMQ.Test.csproj
+++ b/CarrotMQ.RabbitMQ.Test/CarrotMQ.RabbitMQ.Test.csproj
@@ -12,13 +12,13 @@
 
 	<ItemGroup>
         <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
-        <PackageReference Include="meziantou.analyzer" Version="2.0.194">
+        <PackageReference Include="meziantou.analyzer" Version="2.0.211">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.10.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.10.1" />
 		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CarrotMQ.RabbitMQ/CarrotMQ.RabbitMQ.csproj
+++ b/CarrotMQ.RabbitMQ/CarrotMQ.RabbitMQ.csproj
@@ -34,11 +34,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="meziantou.analyzer" Version="2.0.194">
+        <PackageReference Include="meziantou.analyzer" Version="2.0.211">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Documentation/Documentation.csproj
+++ b/Documentation/Documentation.csproj
@@ -11,9 +11,9 @@
 
 	<ItemGroup>
         <PackageReference Include="Docfx.App" Version="2.78.3" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.12.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
-        <PackageReference Include="meziantou.analyzer" Version="2.0.194">
+        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+        <PackageReference Include="meziantou.analyzer" Version="2.0.211">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Examples/FullExample/Aspire/Aspire.csproj
+++ b/Examples/FullExample/Aspire/Aspire.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
-    <PackageReference Include="Aspire.Hosting.RabbitMQ" Version="9.0.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.0" />
+    <PackageReference Include="Aspire.Hosting.RabbitMQ" Version="9.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/FullExample/Client/Client.csproj
+++ b/Examples/FullExample/Client/Client.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CarrotMQ.RabbitMQ" Version="1.0.0-alpha.3" />
+    <PackageReference Include="CarrotMQ.RabbitMQ" Version="1.0.0-alpha.8" />
 
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/FullExample/Dto/Dto.csproj
+++ b/Examples/FullExample/Dto/Dto.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CarrotMQ.Core" Version="1.0.0-alpha.3" />
+    <PackageReference Include="CarrotMQ.Core" Version="1.0.0-alpha.8" />
   </ItemGroup>
 
 </Project>

--- a/Examples/FullExample/Service1/Program.cs
+++ b/Examples/FullExample/Service1/Program.cs
@@ -39,7 +39,7 @@ internal class Program
             .WithMetrics(
                 metricsBuilder =>
                 {
-                    metricsBuilder.AddMeter("CarrotMQ.RabbitMQ.CarrotMeter");
+                    metricsBuilder.AddMeter(Names.CarrotMeterName);
                     metricsBuilder.AddRuntimeInstrumentation();
                 })
             .WithTracing(tracingBuilder => { tracingBuilder.AddSource(Names.CarrotActivitySourceName); })

--- a/Examples/FullExample/Service1/Service1.csproj
+++ b/Examples/FullExample/Service1/Service1.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CarrotMQ.RabbitMQ" Version="1.0.0-alpha.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
+    <PackageReference Include="CarrotMQ.RabbitMQ" Version="1.0.0-alpha.8" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/FullExample/Service2/Service2.csproj
+++ b/Examples/FullExample/Service2/Service2.csproj
@@ -9,10 +9,10 @@
 
 
     <ItemGroup>
-        <PackageReference Include="CarrotMQ.RabbitMQ" Version="1.0.0-alpha.3" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
+        <PackageReference Include="CarrotMQ.RabbitMQ" Version="1.0.0-alpha.8" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Examples/QuickStart/Client/Client.csproj
+++ b/Examples/QuickStart/Client/Client.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CarrotMQ.RabbitMQ" Version="1.0.0-alpha.3" />
+    <PackageReference Include="CarrotMQ.RabbitMQ" Version="1.0.0-alpha.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/QuickStart/Dto/Dto.csproj
+++ b/Examples/QuickStart/Dto/Dto.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CarrotMQ.Core" Version="1.0.0-alpha.3" />
+    <PackageReference Include="CarrotMQ.Core" Version="1.0.0-alpha.8" />
   </ItemGroup>
 
 </Project>

--- a/Examples/QuickStart/Service/Service.csproj
+++ b/Examples/QuickStart/Service/Service.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CarrotMQ.RabbitMQ" Version="1.0.0-alpha.3" />
+    <PackageReference Include="CarrotMQ.RabbitMQ" Version="1.0.0-alpha.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Updated various Microsoft and third-party package references (such as `meziantou.analyzer`, `Microsoft.Extensions.Logging`, `Microsoft.NET.Test.Sdk`, `MSTest`, `Testcontainers.RabbitMq`, `OpenTelemetry`, and `Aspire.Hosting`) to their latest patch or minor versions in both core and test projects. 
* Upgraded `CarrotMQ.Core`, `CarrotMQ.RabbitMQ`, and related example project dependencies to version `1.0.0-alpha.8`. 
* Changed the construction of the RabbitMQ connection string in integration tests to use the container's hostname instead of `127.0.0.1`.
* Updated metric registration in `Service1/Program.cs` to use the constant `Names.CarrotMeterName` instead of a hardcoded string.